### PR TITLE
Update snippet.db2formit.php

### DIFF
--- a/core/components/formit2db/elements/snippets/snippet.db2formit.php
+++ b/core/components/formit2db/elements/snippets/snippet.db2formit.php
@@ -108,10 +108,10 @@ if (is_array($where)) {
             }
         }
         $hook->setValues($formFields);
-    }
-} else {
-    if ($notFoundRedirect) {
-        $modx->sendRedirect($modx->makeUrl($notFoundRedirect));
+    } else {
+        if ($notFoundRedirect) {
+            $modx->sendRedirect($modx->makeUrl($notFoundRedirect));
+        }
     }
 }
 


### PR DESCRIPTION
I was trying to get "notFoundRedirect" to work. It was not working at all for me. So i looked up in the code and saw that the "else"-Option was stick to "if (is_array($where))".
Shouldn't that belong to: "if ($dataobject = $modx->getObject($classname, $where))".
Now it is working fine. Am I wrong?
