### PR TITLE
Added "joins" for related classes.

### DIFF
--- a/core/components/formit2db/elements/snippets/db2formit.snippet.php
+++ b/core/components/formit2db/elements/snippets/db2formit.snippet.php
@@ -28,6 +28,26 @@ $autoPackage = (boolean)$modx->getOption('autoPackage', $scriptProperties, false
 $packagepath = $modx->getOption($packagename . '.core_path', null, $modx->getOption('core_path') . 'components/' . $packagename . '/');
 $modelpath = $packagepath . 'model/';
 
+// $joins = $modx->getOption('joins', $scriptProperties, '[]', true);
+$joins = $modx->fromJson($modx->getOption('joins', $scriptProperties, '[]', true));
+
+// Debug joins
+/*
+echo '<pre>';
+var_dump($joins);
+echo '</pre>';
+*/
+
+// Clear join Array and just maintain names
+$joinCriteria = [];
+
+foreach ($joins as $join) {
+    $className = key($join) !== 0 ? key($join) : $join[0];
+    $joinCriteria[$className] = [];
+}
+
+
+// AutoPackage
 if ($autoPackage) {
     $schemapath = $modelpath . 'schema/';
     $schemafile = $schemapath . $packagename . '.mysql.schema.xml';
@@ -44,7 +64,7 @@ if ($autoPackage) {
         if (!is_dir($schemapath)) {
             mkdir($schemapath, 0777);
         }
-        // Use this to create a schema from an existing database
+        //Use this to create a schema from an existing database
         if (!$generator->writeSchema($schemafile, $packagename, 'xPDOObject', $prefix, true)) {
             $modx->log(modX::LOG_LEVEL_ERROR, 'Could not generate XML schema', '', 'db2FormIt Hook');
         }
@@ -65,9 +85,109 @@ if ($fieldname) {
     }
 }
 
-if (is_array($where)) {
-    if ($dataobject = $modx->getObject($classname, $where)) {
-        $formFields = $dataobject->toArray();
+
+
+// if (is_array($where)) {
+    
+    if(!$joins) {
+        $dataobject = $modx->getObject($classname, $where);
+    } else {
+        $dataobject = $modx->getCollectionGraph($classname, $joinCriteria, $where);
+    }
+    
+
+ 
+    if ($dataobject) {
+        
+        if ($joins && empty($dataobject)) {
+            $errorMsg = 'Failed to create object of type: ' . $classname;
+            $hook->addError('error_message', $errorMsg);
+            $modx->log(modX::LOG_LEVEL_ERROR, $errorMsg, '', 'db2FormIt Hook');
+            return false;
+        } elseif ( !$joins && (!is_object($dataobject) || !($dataobject instanceof xPDOObject)) ) {
+            $errorMsg = 'Failed to create object of type: ' . $classname;
+            $hook->addError('error_message', $errorMsg);
+            $modx->log(modX::LOG_LEVEL_ERROR, $errorMsg, '', 'db2FormIt Hook');
+            return false;
+        }
+        
+        if (empty($dataobject) && $notFoundRedirect) {
+            $modx->sendRedirect($modx->makeUrl($notFoundRedirect));
+        }
+        
+    
+        // -- handle joins 
+        if($joins) 
+        {
+        /* V1 - getCollectionGraph */
+            foreach ($dataobject as $obj)
+            {
+                if (is_object($obj))
+                {
+                    $formFields = $obj->toArray();         
+                    
+                    foreach($joinCriteria as $jClassName => $value) {
+                        $relObj = $obj->getFKDefinition($jClassName);
+                        $relCardinality = $relObj['cardinality'];
+                        
+                        // One
+                        switch($relCardinality) {
+                            case 'one':
+                                $formFields = array_merge($formFields, $obj->toArray($jClassName.'.'));
+                                break;
+                            case 'many':
+                                $i = 0;
+                                foreach($obj->$jClassName as $subObj) 
+                                {
+                                    //print_r($rl->toArray()) ;
+                                    $formFields = array_merge($formFields, $subObj->toArray($jClassName.'.'.$i.'.'));
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+     
+        
+        /* V2 - loop individually */
+        
+        /*
+        $joinObjs = [];
+        $joinSettings = [];
+        */
+        
+        /*
+        foreach ($joins as $join) {
+            // key => value or single value?
+            $className = key($join) !== 0 ? key($join) : $join[0];
+            $relObj = $dataobject->getFKDefinition($className);
+            
+            if($relObj) {
+                $relClass = $relObj['class'];
+                $relCardinality = $relObj['cardinality'];
+                
+                $joinObj = [];
+                
+                switch ($relCardinality) {
+                    case 'one' :
+                        $joinObj = $dataobject->getOne($relClass,$paramname);
+                        $joinObj = $joinObj->toArray($relClass.'.');
+                        break;
+                    case 'many' :
+                        $joinObj = $dataobject->getMany($relClass);
+                        break;
+                }
+                
+                
+                $formFields = array_merge($formFields, $joinObj);
+            }
+        }
+        
+        */
+        
+        }
+        // END handle joins --
+        
         foreach ($formFields as $field => $value) {
             if (in_array($field, $ignoreFields)) {
                 unset($formFields[$field]);
@@ -86,15 +206,11 @@ if (is_array($where)) {
                 }
             }
         }
+        
         $hook->setValues($formFields);
     } else {
         if ($notFoundRedirect) {
             $modx->sendRedirect($modx->makeUrl($notFoundRedirect));
-        }
-    }
-} else {
-    if ($notFoundRedirect) {
-        $modx->sendRedirect($modx->makeUrl($notFoundRedirect));
     }
 }
 

--- a/core/components/formit2db/elements/snippets/formit2db.snippet.php
+++ b/core/components/formit2db/elements/snippets/formit2db.snippet.php
@@ -12,6 +12,7 @@
  *
  * FormIt2db snippet
  */
+
 $prefix = $modx->getOption('prefix', $scriptProperties, $modx->getOption(xPDO::OPT_TABLE_PREFIX), true);
 $packagename = $modx->getOption('packagename', $scriptProperties, '', true);
 $classname = $modx->getOption('classname', $scriptProperties, '', true);
@@ -26,6 +27,56 @@ $autoPackage = (boolean)$modx->getOption('autoPackage', $scriptProperties, false
 
 $packagepath = $modx->getOption($packagename . '.core_path', null, $modx->getOption('core_path') . 'components/' . $packagename . '/');
 $modelpath = $packagepath . 'model/';
+
+/* TO DO
+* 
+* `file` setting for (multiple) file/s
+* `req` setting checking and error handling
+* multi file upload - including formit2file
+* implement formit2file
+* alias-field separator -- currently '_', automatically through naming convention and HTML behavior
+*/
+
+/* Naming convention for fields: 
+* Alias prepended to field name, separated by point 
+* Example name="Alias.field" 
+*/
+
+/* Joins must be JSON notification
+* example: 
+* &joins=`[
+*   {"CommentImages" : {"type" : "file" , "req" : "false"} },
+*   {"CommentThumbnail" : {"type" : "file"} },
+*   ["SingleClass"]
+*   ]`
+*/
+
+$joins = $modx->fromJson($modx->getOption('joins', $scriptProperties, '[]', true));
+$aliasSeparator = '';
+
+// Debug joins
+/*
+echo '<pre>';
+var_dump($joins);
+echo '</pre>';
+*/
+
+$packagepath = $modx->getOption($packagename . '.core_path', NULL, $modx->getOption('core_path') . 'components/' . $packagename . '/');
+$modelpath = $packagepath . 'model/';
+
+// Set LogLevel for debugging
+// $modx->setLogLevel(4);
+
+/*
+$log_target = array(
+    'target'=>'FILE',
+    'options' => array(
+        'filename'=>'my_custom.log'
+    )
+);
+*/
+
+
 
 if ($autoPackage) {
     $schemapath = $modelpath . 'schema/';
@@ -64,6 +115,7 @@ if ($fieldname) {
     }
 }
 
+
 if (is_array($where)) {
     $dataobject = $modx->getObject($classname, $where);
     if (empty($dataobject)) {
@@ -80,23 +132,149 @@ if (!is_object($dataobject) || !($dataobject instanceof xPDOObject)) {
     return false;
 }
 
+
+
 $formFields = $hook->getValues();
+
+/*
+echo '<pre>';
+var_dump($formFields);
+echo '</pre>';
+
+die();
+*/
+
+// Create Array with data for joined Objects
+$joinObjs = [];
+$joinSettings = [];
+
+foreach ($joins as $join) {
+    // Group Join fields in one array
+    $class = key($join) !== 0 ? key($join) : $join[0];
+    $joinSettings[$class] = $join[$class];
+    if (!array_key_exists($class, $formFields) && !is_array($formFields[$class]) ) {
+        $tmpArray = [];
+        foreach ($formFields as $field => $val) {
+            $skey = $class.'_';
+            if( strpos($field, $skey) !== false)  {
+                $sfield = substr($field, strlen($skey));
+                $tmpArray[$sfield] = $val;
+                unset($formFields[$field]);
+            }
+        }
+        $joinObjs[$class] = $tmpArray;
+
+    } elseif (array_key_exists($class, $formFields) && is_array($formFields[$class]) ) {
+        $joinObjs[$class] = $formFields[$class];
+        unset($formFields[$class]);
+    } elseif (array_key_exists($class, $formFields) && isJson($formFields[$class]) ) {
+        $joinObjs[$class] = $modx->fromJson($formFields[$class]);
+        unset($formFields[$class]);
+    }
+}
+
+
+// Debug $formFields after join field removal
+/*
+echo '<pre>';
+var_dump($formFields);
+echo '</pre>';
+
+echo '<pre>';
+var_dump($joinObjs);
+echo '</pre>';
+ 
+
+die();
+*/
+
+// create $dataobject
 foreach ($formFields as $field => $value) {
     if (!in_array($field, $removeFields)) {
         if (in_array($field, $arrayFields)) {
-            switch ($arrayFormat) {
-                case 'json':
-                    $value = json_encode($value);
-                    break;
-                case 'csv' :
-                default :
-                    $value = implode(',', $value);
-                    break;
-            }
+            $value = getArrayFormat($value);
         }
         $dataobject->set($field, $value);
     }
 }
+
+
+// add joined classes to $dataobject
+foreach ($joinObjs as $className => $classData) {
+    $relObj = $dataobject->getFKDefinition($className);
+    
+    if($joinSettings[$className]['type'] == 'file' && $classData['error'] == 4 ) {
+        $hasData = false;
+    } else {
+        $hasData = array_filter($classData);
+    }
+    
+    if ($relObj && $hasData) {
+        $relClass = $relObj['class'];
+        $relCardinality = $relObj['cardinality'];
+        
+        $addObj = $modx->newObject($relClass);
+        
+        foreach ($classData as $field => $value) {
+            if (!empty($value) && isJson($value)) {
+                $addObj->fromJson($value);
+            } elseif (is_array($value)) {
+                $value = getArrayFormat($value);
+                $addObj->set($field, $value);
+            } else {
+                $addObj->set($field, $value);
+            }
+                
+        }
+    
+        switch ($relCardinality) {
+            case 'one' :
+                $dataobject->addOne($addObj);
+                break;
+            case 'many' :
+                $dataobject->addMany($addObj);
+                break;
+        }
+        
+        /* Debugging      
+        $a = $addObj->toArray(); 
+        echo 'ADD OBJ <pre>';
+        print_r($a); 
+        echo '</pre>';
+        */
+    } elseif (!$hasData) {        
+    // } elseif (!$hasData && $joinSettings[$className]['req'] == true) {        
+        // $errorMsg = 'Data for a required field is missing!';
+        // $hook->addError('error_message', $errorMsg);
+        $errorMsg = 'No submitted data for required field: ' . $className . '<br />. Skipping this one.';
+        $modx->log(modX::LOG_LEVEL_ERROR, $errorMsg, '', 'FormIt2db Hook');
+
+    } else {
+        $errorMsg = 'Could not find related class: ' . $className . '<br /> Skipping this one.';
+        $modx->log(modX::LOG_LEVEL_ERROR, $errorMsg, '', 'FormIt2db Hook');
+    }                  
+}
+
+
+// Debug dataobject
+/*
+echo 'DATAOBJ';
+$a = $dataobject->toArray(); 
+        echo '<pre>';
+        print_r($a); 
+        echo '</pre>';
+
+
+die();
+
+
+$allFormFields = $hook->getValues();
+        echo '<pre>';
+        print_r($allFormFields); 
+        echo '</pre>';
+
+*/
+
 
 if (!$dataobject->save()) {
     $errorMsg = 'Failed to save object of type: ' . $classname;
@@ -104,4 +282,36 @@ if (!$dataobject->save()) {
     $modx->log(modX::LOG_LEVEL_ERROR, $errorMsg, '', 'FormIt2db Hook');
     return false;
 }
+
 return true;
+
+
+/* Functions */
+
+function isJson($string) {
+ json_decode($string);
+ return (json_last_error() == JSON_ERROR_NONE);
+}
+
+function getArrayFormat($value) {
+    switch ($arrayFormat) {
+        case 'json':
+            $value = json_encode($value);
+            break;
+        case 'csv' :
+        default :
+            $value = implode(',', $value);
+            break;
+        }
+    return $value;
+};
+
+
+// Not needed
+/*
+function flatten_array(array $array) {
+    $return = array(); 
+    array_walk_recursive($array, function($a,$b) use (&$return) { $return[$b] = $a; }); 
+    return $return; 
+};
+*/


### PR DESCRIPTION
Can save and retrieve related classes for parent class.
Raw version with commented out debug code, not fully tested!

Added "joins" property.
- Naming convention for forms: class name prepended to fields name, like 
  `<input name="Alias.field">`
- Property input must be JSON notification 
  Example:  

```
&joins=`[
 {"CommentImages" : {"type" : "file" , "req" : "false"} },
 {"CommentThumbnail" : {"type" : "file"} },
 ["SingleClass"]
]`
```

_required_ not yet implemented

Also checks for files and empty file fields; can be used with formit2file hook (file data has to be passed e.g. by $hook->setValue($sfile,$jsonData))
